### PR TITLE
Enable logging on embedded SDM commands

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -15,16 +15,20 @@
  * limitations under the License.
  */
 
+import {
+    cliCommand,
+    isEmbeddedSdmCommand,
+    isReservedCommand,
+} from "./lib/command";
+
 process.env.SUPPRESS_NO_CONFIG_WARNING = "true";
-process.env.ATOMIST_DISABLE_LOGGING = "true";
+if (!isEmbeddedSdmCommand(process.argv)) {
+    process.env.ATOMIST_DISABLE_LOGGING = "true";
+}
 
 import { addLocalSdmCommands } from "@atomist/sdm-local";
 import * as yargs from "yargs";
 
-import {
-    cliCommand,
-    isReservedCommand,
-} from "./lib/command";
 import { config } from "./lib/config";
 import { execute } from "./lib/execute";
 import { git } from "./lib/git";

--- a/lib/command.ts
+++ b/lib/command.ts
@@ -38,6 +38,15 @@ export function isReservedCommand(args: string[]): boolean {
 }
 
 /**
+ * Does this command start up an embedded SDM?
+ * @param args command-line arguments, typically process.argv
+ */
+export function isEmbeddedSdmCommand(args: string[]) {
+    const relevant = args.slice(2);
+    return relevant.length > 0 && ["new sdm"].includes(relevant.join(" "));
+}
+
+/**
  * Call the provided function with the provided arguments and capture
  * any errors.  When the function is complete, `process.exit` will be
  * called with the appropriate code, i.e., this function will never return.


### PR DESCRIPTION
We need not to irrevocably disable logging if we are going to start an embedded SDM as then its output is lost to the user. It would be better to have finer-grained control of logging in a  process but it seems at present that once it's disabled, it's gone for good.