### PR TITLE
Allow undeclared modules.

### DIFF
--- a/lib/typings/index.ts
+++ b/lib/typings/index.ts
@@ -1,0 +1,1 @@
+declare module "*";

--- a/lib/typings/index.ts
+++ b/lib/typings/index.ts
@@ -1,1 +1,17 @@
+/*
+ * Copyright © 2018 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 declare module "*";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,6 +27,10 @@
         "node_modules",
         ".#*"
     ],
+    "files": [
+        "index.ts",
+        "lib/typings/index.ts"
+    ],
     "compileOnSave": true,
     "buildOnSave": false,
     "atom": {


### PR DESCRIPTION
This accommodates 'npm link' while retaining the rest of the value of noImplicitAny
The 'OMG you didn't name that module' part is the least useful part of noImplicitAny, anyway

This lets cli compile without errors even when sdm-local is npm-linked in
It's not perfect, but it's progress.