### PR TITLE
Recognize graphql directory at root

### DIFF
--- a/lib/gql.ts
+++ b/lib/gql.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Atomist, Inc.
+ * Copyright © 2019 Atomist, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/gql.ts
+++ b/lib/gql.ts
@@ -25,14 +25,18 @@ import * as path from "path";
  * @param cwd directory to use as base for location of lib dir
  * @return Resolved, full path to lib directory
  */
-export function libDir(cwd: string): string {
-    const lib = path.resolve(cwd, "lib");
-    const src = path.resolve(cwd, "src");
+export function graphqlDir(cwd: string): string {
+    const graphql = path.resolve(cwd, "graphql");
+    if (fs.existsSync(graphql)) {
+        return graphql;
+    }
+    const lib = path.resolve(cwd, "lib", "graphql");
+    const src = path.resolve(cwd, "src", "graphql");
     if (fs.existsSync(lib)) {
         return lib;
     } else if (fs.existsSync(src)) {
         return src;
     } else {
-        return lib;
+        return graphql;
     }
 }

--- a/lib/gqlFetch.ts
+++ b/lib/gqlFetch.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Atomist, Inc.
+ * Copyright © 2019 Atomist, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/gqlFetch.ts
+++ b/lib/gqlFetch.ts
@@ -18,7 +18,7 @@ import * as fs from "fs-extra";
 import * as path from "path";
 
 import { resolveCliConfig } from "./cliConfig";
-import { libDir } from "./gql";
+import { graphqlDir } from "./gql";
 import * as print from "./print";
 import { spawnBinary } from "./spawn";
 
@@ -54,7 +54,7 @@ export async function gqlFetch(opts: GqlFetchOptions): Promise<number> {
     const graphQL = cliConfig.endpoints && cliConfig.endpoints.graphql
         ? cliConfig.endpoints.graphql : "https://automation.atomist.com/graphql/team";
 
-    const outDir = path.join(libDir(opts.cwd), "graphql");
+    const outDir = graphqlDir(opts.cwd);
     const outSchema = path.join(outDir, "schema.json");
     await fs.ensureDir(outDir);
     const spawnOpts = {

--- a/test/gql.test.ts
+++ b/test/gql.test.ts
@@ -19,31 +19,66 @@ import * as path from "path";
 import * as assert from "power-assert";
 import * as tmp from "tmp-promise";
 
-import { libDir } from "../lib/gql";
+import { graphqlDir } from "../lib/gql";
 
 describe("gql", () => {
 
     describe("libDir", () => {
 
-        it("should find lib dir", () => {
-            const l = libDir(path.join(__dirname, ".."));
-            const e = path.resolve(__dirname, "..", "lib");
-            assert(l === e);
+        it("should find lib/graphql dir", async () => {
+            const t = await tmp.dir({ unsafeCleanup: true });
+            const e = path.resolve(t.path, "lib");
+            await fs.ensureDir(e);
+            const g = path.join(e, "graphql");
+            await fs.ensureDir(g);
+            const l = graphqlDir(path.join(t.path));
+            assert(l === g);
         });
 
-        it("should find src dir", async () => {
+        it("should find src/graphql dir", async () => {
             const t = await tmp.dir({ unsafeCleanup: true });
             const e = path.join(t.path, "src");
             await fs.ensureDir(e);
-            const l = libDir(t.path);
-            assert(l === e);
+            const g = path.join(e, "graphql");
+            await fs.ensureDir(g);
+            const l = graphqlDir(t.path);
+            assert.strictEqual(l, g);
             await t.cleanup();
         });
 
-        it("should return lib when there is no dir", () => {
-            const l = libDir(__dirname);
-            const e = path.resolve(__dirname, "lib");
-            assert(l === e);
+        it("should return /graphql when there is no lib or src", () => {
+            const l = graphqlDir(__dirname);
+            const expected = path.join(__dirname, "graphql");
+            assert.strictEqual(l, expected);
+        });
+
+        it("should return root/graphql when there is lib but no lib/graphql", async () => {
+            const t = await tmp.dir({ unsafeCleanup: true });
+            const e = path.join(t.path, "lib");
+            await fs.ensureDir(e);
+            const l = graphqlDir(t.path);
+            const expected = path.join(t.path, "graphql");
+            assert.strictEqual(l, expected);
+            await t.cleanup();
+        });
+
+        it("should return root/graphql when there is src but no src/graphql", async () => {
+            const t = await tmp.dir({ unsafeCleanup: true });
+            const e = path.join(t.path, "src");
+            await fs.ensureDir(e);
+            const l = graphqlDir(t.path);
+            const expected = path.join(t.path, "graphql");
+            assert.strictEqual(l, expected);
+            await t.cleanup();
+        });
+
+        it("should return graphql/ if it has graphql", async () => {
+            const t = await tmp.dir({ unsafeCleanup: true });
+            const g = path.join(t.path, "graphql");
+            await fs.ensureDir(g);
+            const result = graphqlDir(t.path);
+            assert.strictEqual(result, g);
+            await t.cleanup();
         });
 
     });


### PR DESCRIPTION
So you can have graphql/schema.json in the root of the project directory.

This is the new default.